### PR TITLE
INV-1514 Handle falsy preset values and empty arrays

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -59,6 +59,18 @@ describe('src/index.ts', () => {
         required: false,
         preset: '123456789',
       },
+      {
+        key: 'ADDITIONAL_CONNECTION_PROPERTIES',
+        type: 'string',
+        required: false,
+        preset: '',
+      },
+      {
+        key: 'EXCLUSIONS',
+        type: 'integersArray',
+        required: false,
+        preset: '',
+      },
     ];
 
     const env = TrustEnv(contract);
@@ -77,6 +89,8 @@ describe('src/index.ts', () => {
       MONGODB_DEFAULT_USER: { name: 'Foo' },
       MONGODB_SSL: undefined,
       MONGODB_ROOT_PASSWORD: 123456789,
+      ADDITIONAL_CONNECTION_PROPERTIES: '',
+      EXCLUSIONS: [],
     });
     expect(env.getPrefix('API')).toEqual({
       API_URL: 'https://endpoint-a.pi/v3',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,7 +85,7 @@ const extractEnvVariables = (contract: Contract): Variables =>
         throw new EntryValueNotFoundError(entry);
       }
 
-      if (preset) {
+      if (preset !== undefined) {
         rawValue = preset;
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,13 @@ const castToType = (value: string, type: CastType) => {
     return;
   }
 
+  if (
+    value === '' &&
+    (type === 'stringsArray' || type === 'integersArray' || type === 'numbersArray')
+  ) {
+    return [];
+  }
+
   switch (type) {
     case 'stringsArray':
       return value.split(',').map((item) => item.toString());


### PR DESCRIPTION
## [Context](https://cubynjira.atlassian.net/browse/INV-1514)

Check `preset` strictly against `undefined` to allow falsy values like `0` and `''`. Additionally, parse `''` as an empty array for array types to prevent parsing it as `[ '' ]` or `[ NaN ]`.